### PR TITLE
Fixed hashed passwords presented in KeePass

### DIFF
--- a/src/kdbx.cc
+++ b/src/kdbx.cc
@@ -190,7 +190,7 @@ void KdbxFile::WriteProtectedString(pugi::xml_node& node,
                                     const protect<std::string>& str,
                                     RandomObfuscator& obfuscator) const {
   if (str.is_protected()) {
-    node.append_attribute("Protected").set_value(true);
+    node.append_attribute("Protected").set_value("True");
     node.text().set(base64_encode(obfuscator.Process(*str)).c_str());
   } else {
     node.text().set(str->c_str());


### PR DESCRIPTION
Fixed issue with exported kdbx files: entries' passwords presented hashed, when opened with KeePass app (version 2.38 for Windows OS)